### PR TITLE
[BUG] Two bug fixes and integration tests to cover them

### DIFF
--- a/greensim/__init__.py
+++ b/greensim/__init__.py
@@ -15,7 +15,7 @@ import greenlet
 
 from greensim.tags import Tags, TaggedObject
 
-GREENSIM_TAG_ATTRIBUTE = "_greensim_tag_set"
+GREENSIM_TAG_ATTRIBUTE = "_greensim_tags"
 
 # Disable auto-logging by default: it bears a significant weight on performance. Auto-logging will be toggled using
 # enable_logging() and disable_logging().
@@ -468,14 +468,14 @@ def happens(intervals: Iterable[float], name: Optional[str] = None) -> Callable:
     return hook
 
 
-def tagged(*tag_set: Tags) -> Callable:
+def tagged(*tags: Tags) -> Callable:
     global GREENSIM_TAG_ATTRIBUTE
     """
     Decorator for adding a label to the process.
     These labels are applied to any child Processes produced by event
     """
     def hook(event: Callable):
-        setattr(event, GREENSIM_TAG_ATTRIBUTE, tag_set)
+        setattr(event, GREENSIM_TAG_ATTRIBUTE, tags)
         return event
     return hook
 

--- a/greensim/__init__.py
+++ b/greensim/__init__.py
@@ -347,9 +347,15 @@ class Process(greenlet.greenlet, TaggedObject):
         # Collect tags from the process spawning this one, and anything attached to the function
         if Process.current_exists():
             self.tag_with(*Process.current()._tag_set)
+        # Due to the way Greenlets are reused in memory, tags can persist across simulations
+        # This makes sure that the Process is fresh if a simulation is not current running
+        # Moving this outside the else statement will cause it to wipe tags from the currently
+        # running process, if one exists. This will require further research
+        else:
+            self.clear_tags()
 
         if hasattr(run, GREENSIM_TAG_ATTRIBUTE):
-            self.tag_with(getattr(run, GREENSIM_TAG_ATTRIBUTE))
+            self.tag_with(*getattr(run, GREENSIM_TAG_ATTRIBUTE))
 
     @staticmethod
     def current() -> 'Process':
@@ -469,7 +475,7 @@ def tagged(*tag_set: Tags) -> Callable:
     These labels are applied to any child Processes produced by event
     """
     def hook(event: Callable):
-        setattr(event, GREENSIM_TAG_ATTRIBUTE, *tag_set)
+        setattr(event, GREENSIM_TAG_ATTRIBUTE, tag_set)
         return event
     return hook
 

--- a/tests/integ/test_tag_propogation.py
+++ b/tests/integ/test_tag_propogation.py
@@ -1,0 +1,150 @@
+from greensim import GREENSIM_TAG_ATTRIBUTE, now, Process, Simulator, tagged
+from greensim.tags import Tags
+
+
+# Greensim has an unusual allocation pattern that will cause this test to fail if the call to clear_tags()
+# is removed from the Process __init__ method. The greenlet that calls tag_carrier will be recycled
+# and will be used to call tag_receiver, and since it is not a new construction it will retain the
+# tag that it initially took from tag_carrier
+
+
+def test_tag_clear():
+    sim._clear()
+
+    @tagged(IntegTestTag.CANADA)
+    def tag_carrier():
+        pass
+
+    sim.add(tag_carrier)
+    sim.run()
+
+    def tag_receiver():
+        assert not Process.current().has_tag(IntegTestTag.CANADA)
+
+    sim.add(tag_receiver)
+    sim.run()
+
+
+############################################################
+# Define constants for the many tests of add(_in, _at) #
+############################################################
+
+
+class IntegTestTag(Tags):
+    ALICE = 0
+    BOB = ""
+    CANADA = {}
+
+
+flag = 0
+sim = Simulator()
+
+
+####################################################################################
+# Helper functions to deal with simulations in the many tests of add(_in, _at) #
+####################################################################################
+
+
+# Wraps an arbitrary function in order to check that it is being called at the right time
+# The returned function takes the tags of the argument function
+def create_time_check(delay, fn):
+    def time_check(*args, **kwargs):
+        nonlocal delay, fn
+        assert delay == now()
+        fn(*args, **kwargs)
+
+    # NB this is discouraged in Production code. Tags should be applied at the top level,
+    # where they can be propogated down. This is just to keep the test helper generic
+    if hasattr(fn, GREENSIM_TAG_ATTRIBUTE):
+        time_check = tagged(*getattr(fn, GREENSIM_TAG_ATTRIBUTE))(time_check)
+
+    return time_check
+
+
+# Vanilla add, just passes arguments through and checks that fn is run using flag
+def run_add(fn, *args, **kwargs):
+    global flag
+    flag = 0
+    sim._clear()
+    sim.add(fn, *args, **kwargs)
+    sim.run()
+    assert flag == 1
+
+
+# Wraps fn in another function that checks the delay happened and passes arguments and tags through
+def run_add_at(fn, *args, **kwargs):
+    global flag
+    flag = 0
+    delay = 10
+
+    sim._clear()
+    sim.add_at(delay, create_time_check(delay, fn), *args, **kwargs)
+    sim.run()
+    assert flag == 1
+
+
+# Same as above, but runs the simulation first to make sure the relative functionality of _in is used
+def run_add_in(fn, *args, **kwargs):
+    global flag
+    flag = 0
+    delay = 10
+
+    sim._clear()
+    sim.run(delay)
+    sim.add_in(delay, create_time_check(2 * delay, fn), *args, **kwargs)
+    sim.run()
+    assert flag == 1
+
+
+short_tag_set = set([IntegTestTag.ALICE, IntegTestTag.BOB])
+
+
+@tagged(*short_tag_set)
+def tag_checker(tag_set):
+    global flag, short_tag_set
+    flag = 1
+    assert tag_set == Process.current()._tag_set
+
+
+def test_add_tags():
+    run_add(tag_checker, short_tag_set)
+
+
+def test_add_at_tags():
+    run_add_at(tag_checker, short_tag_set)
+
+
+def test_add_in_tags():
+    run_add_in(tag_checker, short_tag_set)
+
+
+# As defined in the __init__ method of Process, a new Process should take tags from
+# the function it is passed, as well as the currently running Process
+# These test that add shows consistent behavior
+
+
+def test_add_propogate():
+
+    @tagged(IntegTestTag.CANADA)
+    def tag_propogator(tag_set):
+        sim.add(tag_checker, tag_set | set([IntegTestTag.CANADA]))
+
+    run_add(tag_propogator, short_tag_set)
+
+
+def test_add_at_propogate():
+
+    @tagged(IntegTestTag.CANADA)
+    def tag_propogator(tag_set):
+        sim.add_at(now() + 10, create_time_check(now() + 10, tag_checker), tag_set | set([IntegTestTag.CANADA]))
+
+    run_add_at(tag_propogator, short_tag_set)
+
+
+def test_add_in_propogate():
+
+    @tagged(IntegTestTag.CANADA)
+    def tag_propogator(tag_set):
+        sim.add_in(10, create_time_check(now() + 10, tag_checker), tag_set | set([IntegTestTag.CANADA]))
+
+    run_add_in(tag_propogator, short_tag_set)

--- a/tests/integ/test_tag_propogation.py
+++ b/tests/integ/test_tag_propogation.py
@@ -49,7 +49,6 @@ sim = Simulator()
 # The returned function takes the tags of the argument function
 def create_time_check(delay, fn):
     def time_check(*args, **kwargs):
-        nonlocal delay, fn
         assert delay == now()
         fn(*args, **kwargs)
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -676,6 +676,16 @@ def test_tagged_constructor():
     assert proc.has_tag(TestTag.ALICE)
 
 
+def test_tagged_constructor_multi():
+    @tagged(TestTag.ALICE, TestTag.BOB)
+    def f():
+        pass
+
+    proc = Process(Simulator(), f, None)
+    assert proc.has_tag(TestTag.ALICE)
+    assert proc.has_tag(TestTag.BOB)
+
+
 def run_test_tagged_add(tagged_launcher, stop):
     when_last = 0.0
 


### PR DESCRIPTION
When writing integrations tests for the tag functionality two bugs arose

1) Unpacking arguments: The [original PR](https://github.com/ElementAI/greensim/pull/37) that laid out the tags functionality contained a bug and a gap in the unit tests for the `@tagged` decorator. `@tagged` unpacked the `tag_set` argument passed to it immediately before calling `setattr` on the function definition, which resulted in too many arguments being passed if `@tagged` was called with multiple arguments. This was not covered in unit tests so it was missed. The change simply moves the unpacking to the call to `tag_with`, which is part of the `TaggedObject` API and takes an arbitrary number of arguments by design. The tags remain in a tuple when they are stored on the function definition.

2) Greenlet persistence: The causes of this bug are not entirely clear and will require more research. There are two components
a) If the call to `clear_tags` in the `__init__` method of `Process` is removed, `test_tag_clear` will fail. This is because the tags that are placed on the initial `Process`, which runs in the simulation and has no reference afterwards, will be retained in memory. When a new `Process` is created later, it will retain the tags from the original, indicating that the new greenlet is likely to be the original greenlet, just recycled
b) On the other hand, if the call to `clear_tags` is moved out of the `else` clause so that it is called in cases where a `Process` is currently running, many other tests will fail. This is because the call will actually clear the tags from `Process.current()`, preventing them from being propagated. This seems to indicate that calls to `__init__` are not actually creating entirely new greenlets, but are modifying existing objects in some way.

This PR corrects both bugs, noting that further research is necessary to understand them. It also adds integration tests to ensure that tag propagation is handled in the expected way and adds a unit test to cover the issue in (1)