### PR TITLE
[NON-BLOCKING] Tag fixes

### DIFF
--- a/get_binding.md
+++ b/get_binding.md
@@ -1,0 +1,82 @@
+Any time a variable is accessed as an attribute, the underlying method `__get__` is called on the variable
+
+```
+>>> class A:
+...     def __get__(*args):
+...         print("Getting an A")
+... 
+>>> class B:
+...     a = A()
+... 
+>>> B.a
+Getting an A
+```
+
+See: https://docs.python.org/3.7/howto/descriptor.html#id5
+
+This method can also take arguments, which affect the scope into which the requested variable is bound. If an object instance is provided as the first argument, the variable on which `__get__` was called will be bound to the scope of that instance
+
+```
+>>> class A:
+...     def __init__(self):
+...         self.message = "I'm from A"
+... 
+>>> class B:
+...     def print_message(self):
+...         print(self.message)
+...         print(self.__class__)
+...
+
+>>> B().print_message()
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "<stdin>", line 3, in print_message
+AttributeError: 'B' object has no attribute 'message'
+
+
+>>> B.print_message.__get__(A())
+<bound method B.print_message of <__main__.A object at 0x7fa4f1e8f860>>
+
+
+>>> B.print_message.__get__(A())()
+I'm from A
+<class '__main__.A'>
+```
+
+See: https://docs.python.org/3.7/reference/datamodel.html?highlight=metaclass#implementing-descriptors
+
+Notice how above, the instance `B()` does not normally have access to `message`, but by giving the `__get__` method an instance `A()`, which does have `message`, the method `print_message` from `B` was returned, bound to the scope of the `A()` instance. Thus, when it was called, the instance `A()` was used as the scope and the `message` variable was readily accessed. The `print(self.__class__)` call is used to prove that the method is running on the `A()` instance (since the result is `<class '__main__.A'>`), as opposed to giving the `B` object access to the `message` variable
+
+This pattern is used by the `super()` method to bind the `__init__` of the parent class to the context of the child, and can be used directly by the programmer if desired:
+
+```
+>>> class A(object):
+...     def __init__(self):
+...         self.a = "Living in an A"
+... 
+>>> class B(A):
+...     def __init__(self):
+...         super().__init__()
+...         print(self.a)
+... 
+>>> class C(A):
+...     def __init__(self):
+...         A.__init__.__get__(self)()
+...         print(self.a)
+... 
+>>> isinstance(B(), A)
+Living in an A
+True
+>>> isinstance(C(), A)
+Living in an A
+True
+```
+
+See: https://docs.python.org/3.7/reference/datamodel.html?highlight=metaclass#invoking-descriptors
+
+This is typically not necessary, but in the case of multiple inheritance it has the benefit of directly specifying the `__init__` method that should be called, rather than letting Python search `__mro__` with its own pattern. This is used in the `Process` constructor in order to make sure that both the constructors for `greenlet.greenlet` and `TaggedObject` are called, since without both calls the `Process` object would be improperly initialized and unusual behavior would result.
+
+
+Other reading:
+
+https://docs.python.org/3.7/reference/executionmodel.html?highlight=binding#resolution-of-names

--- a/get_binding.md
+++ b/get_binding.md
@@ -45,7 +45,7 @@ I'm from A
 
 See: https://docs.python.org/3.7/reference/datamodel.html?highlight=metaclass#implementing-descriptors
 
-Notice how above, the instance `B()` does not normally have access to `message`, but by giving the `__get__` method an instance `A()`, which does have `message`, the method `print_message` from `B` was returned, bound to the scope of the `A()` instance. Thus, when it was called, the instance `A()` was used as the scope and the `message` variable was readily accessed. The `print(self.__class__)` call is used to prove that the method is running on the `A()` instance (since the result is `<class '__main__.A'>`), as opposed to giving the `B` object access to the `message` variable
+Notice how above, the instance `B()` does not have access to `message`, but by giving the `__get__` method an instance `A()`, which does have `message`, the method `print_message` from `B` was returned, bound to the scope of the `A()` instance. Thus, when it was called, the instance `A()` was used as the scope and the `message` variable was readily accessed. The `print(self.__class__)` call is used to prove that the method is running on the `A()` instance (since the result is `<class '__main__.A'>`), as opposed to giving the `B` object access to the `message` variable.
 
 This pattern is used by the `super()` method to bind the `__init__` of the parent class to the context of the child, and can be used directly by the programmer if desired:
 
@@ -72,39 +72,32 @@ Living in an A
 True
 ```
 
-See: https://docs.python.org/3.7/reference/datamodel.html?highlight=metaclass#invoking-descriptors
+See "Super Binding": https://docs.python.org/3.7/reference/datamodel.html?highlight=metaclass#invoking-descriptors
 
 This is typically not necessary, but in the case of multiple inheritance it has the benefit of directly specifying the `__init__` method that should be called, rather than letting Python search `__mro__` with its own pattern. This is used in the `Process` constructor in order to make sure that both the constructors for `greenlet.greenlet` and `TaggedObject` are called, since without both calls the `Process` object would be improperly initialized and unusual behavior would result.
 
 The reason this was required was that a bug emerged where Tags would persist across `Process` objects in unexpected ways. This was patched incorrectly in https://github.com/ElementAI/greensim/commit/3dd1a50c00002703de825577c49cae256bd91644
 
-As it turns out, if the super class is not properly initialized, it can persist values across multiple instantiations of its subclasses. An example is provided below.
+As it turns out, if the a class is not properly initialized, it can persist values across multiple instantiations of itself (and therefore its subclasses). An example is provided below.
 
 ```
 >>> class A(object):
+...     a = set()
 ...     def update(self):
-...         self.a = 1
+...         self.a |= set([1])
 ... 
->>> class B(A):
-...     def call_update(self):
-...         self.update()
-...     def print_a(self):
-...         print(self.a)
-... 
->>> b = B()
->>> b.print_a()
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-  File "<stdin>", line 5, in print_a
-AttributeError: 'B' object has no attribute 'a'
->>> b.call_update()
->>> b.print_a()
-1
->>> bb = B()
->>> b.print_a()
-1
+>>> a = A()
+>>> a.a
+set()
+>>> a.update()
+>>> a.a
+{1}
+>>> aa = A()
+>>> aa.a
+{1}
 ```
 
+This seems to be a corner case for the interpreter, since changing the `|=` to a `=` or changing the line to `self.a = self.a | set([1])`, which should be equivalent, both prevent the unusual behavior (i.e., the last line of output is `set()`, not `{1}`).
 
 Other reading:
 

--- a/greensim/__init__.py
+++ b/greensim/__init__.py
@@ -475,8 +475,10 @@ def tagged(*tags: Tags) -> Callable:
     These labels are applied to any child Processes produced by event
     """
     def hook(event: Callable):
-        setattr(event, GREENSIM_TAG_ATTRIBUTE, tags)
-        return event
+        def wrapper(*args, **kwargs):
+            event(*args, **kwargs)
+        setattr(wrapper, GREENSIM_TAG_ATTRIBUTE, tags)
+        return wrapper
     return hook
 
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -6,8 +6,8 @@ from typing import List, Callable
 import greenlet
 import pytest
 
-from greensim import Simulator, Process, Named, now, advance, pause, add, happens, local, Queue, Signal, select, \
-    Resource, add_in, add_at, tagged
+from greensim import GREENSIM_TAG_ATTRIBUTE, Simulator, Process, Named, now, advance, pause, add, happens, local, \
+    Queue, Signal, select, Resource, add_in, add_at, tagged
 from greensim.tags import Tags
 
 
@@ -674,6 +674,23 @@ def test_tagged_constructor():
 
     proc = Process(Simulator(), f, None)
     assert proc.has_tag(TestTag.ALICE)
+
+
+def test_tag_in_place():
+    # Standard usage
+    @tagged(TestTag.ALICE)
+    def f():
+        pass
+
+    assert getattr(f, GREENSIM_TAG_ATTRIBUTE) == (TestTag.ALICE,)
+
+    def g():
+        pass
+
+    # Tag function in place
+    assert getattr(tagged(TestTag.BOB)(g), GREENSIM_TAG_ATTRIBUTE) == (TestTag.BOB,)
+    # SHow that this does not affect the original definition
+    assert not hasattr(g, GREENSIM_TAG_ATTRIBUTE)
 
 
 def test_tagged_constructor_multi():


### PR DESCRIPTION
This makes one minor and one major fix:

The minor fix is to the `@tagged` decorator, to make sure that it does not apply tags to functions when it is used as a function and not as a decorator. This use case is demonstrated in the new unit test `test_tag_in_place`. It is enabled by wrapping the argument in a new function, which the decorator returns. Because of [the way decorators are designed](https://www.python.org/dev/peps/pep-0318/#current-implementation-history) this wrapping has no effect on the normal usage.

The major fix is to the constructor for `Process`. In [a previous commit](https://github.com/ElementAI/greensim/commit/3dd1a50c00002703de825577c49cae256bd91644) an if-else clause was added to clear `Tags` from an object in the case that it was new and should not have `Tags` at all. This was to patch the strange behavior where `Tags` would seem to persist from one `Process` to another even after the first should have been garbage collected. As it turns out, the true root cause was that the `TaggedObject` constructor was never called, and so proper initialization was not performed. The last section of get_binding.md has a toy example of the behavior that was observed.

The remedy for this is to make sure that the constructors of both Process super classes are called. This is non-trivial in Python because the `super()` method, which tucks instance binding neatly behind the scenes, searches programmatically for a single implementation of the method that is called upon it. Given that two methods were required in this case, the choices were to either perform a small hack of the search (described in docstring) or call on the methods and data structures underneath `super()` directly. The second choice is simpler and more direct, but requires an understanding of descriptors and in particular how `__get__` can be called leveraged to access variables across scopes. That description, along with some toy examples, is written into get_binding.md. The implementation is in the one-line function `_bind_and_call_constructor`, which has a docstring that also provides some context.

As described in the last section of get_binding.md, this can also be resolved by just changing the operators around, which I did in [an example branch](https://github.com/ElementAI/greensim/commit/ac2c8e4bc4878b11ab3de65a0d10132f580a39ed). I don't like that fix since it is not clear to me that it is even correct behavior